### PR TITLE
Fix a bug in node expansion

### DIFF
--- a/src/options/options_base.rs
+++ b/src/options/options_base.rs
@@ -52,7 +52,7 @@ macro_rules! create_option_structs {
 
 create_option_structs!(
     "Hash"            => hash:          SpinOptionInt, 32, 1, 131072;
-    "Threads"         => threads:       SpinOptionInt, 1, 1, 2;
+    "Threads"         => threads:       SpinOptionInt, 1, 1, 32;
     "MoveOverhead"    => move_overhead: SpinOptionInt, 100, 0, 500;
     "MultiPV"         => multi_pv:      SpinOptionInt, 1, 1, 256;
     "UCI_ShowWDL"     => show_wdl:      CheckBool,     false;

--- a/src/search/tree/node/node_base.rs
+++ b/src/search/tree/node/node_base.rs
@@ -158,6 +158,10 @@ impl Node {
     ) {
         let mut actions = self.actions_mut();
 
+        if !actions.is_empty() {
+            return;
+        }
+
         let mut inputs: Vec<usize> = Vec::with_capacity(32);
         PolicyNetwork::map_policy_inputs::<_, STM_WHITE, NSTM_WHITE>(position.board(), |idx| {
             inputs.push(idx)


### PR DESCRIPTION
When a thread tries to expand the same node another thread is already expanding, the thread has to wait for the other thread to realease to lock on actions. However after the lock is released, the new edges are already added, meaning the second thread will duplicate the edges. The thing I suspect to be the reason this is super bad is because the first thread set all his Node indices to NodeIndex::NULL, which is a large number. The second thread now reads those large numbers when trying to calculate the policy total, leading to the total being inf (exp(u32::MAX / 1000) == inf, its not actually u32::MAX / 1000 because of floating points stuff but quite close). This then leads to the second thread relabeling all policies to zero (p / inf == 0) meaning the edges are selected solely based on q in the expansion phase. This is sometimes quite bad leading to blunders.

This fix is quite dirty, if another thread expanded the node already, just abort expansion (note self.has_children() can not be used because it tries to hold get lock thats already being held)

I ran a quick test fix 3th vs main 1th:
```
Results of dev vs main (8+0.08, 3t - 1t, 1024MB, UHO_Lichess_4852_v1.epd):
Elo: 168.40 +/- 98.63, nElo: 315.87 +/- 152.27
LOS: 100.00 %, DrawRatio: 30.00 %, PairsRatio: inf
Games: 20, Wins: 12, Losses: 3, Draws: 5, Points: 14.5 (72.50 %)
Ptnml(0-2): [0, 0, 3, 5, 2], WL/DD Ratio: inf
```

Its SSS but I was too impatient to let it run longer.

I also noticed that the bug is for some reason not as prevalent at very short tcs (2+0.02) so I think further testing should be conducted at around usual STC time controls