### PR TITLE
Endgame improvements

### DIFF
--- a/engine/src/search_engine/mcts/iteration/simulate.rs
+++ b/engine/src/search_engine/mcts/iteration/simulate.rs
@@ -72,7 +72,9 @@ fn get_position_score(position: &ChessPosition, node_state: GameState, contempt:
     
     let sign = if is_stm { 1.0 } else { -1.0 };
     
-    contempt.rescale(&mut win_lose_delta, &mut draw_chance, sign, false, options);
+    if position.board().phase() > 8 {
+        contempt.rescale(&mut win_lose_delta, &mut draw_chance, sign, false, options);
+    }
     
     let new_win_chance = (1.0 + win_lose_delta - draw_chance) / 2.0;
     

--- a/engine/src/search_engine/tree/tree_expand.rs
+++ b/engine/src/search_engine/tree/tree_expand.rs
@@ -155,6 +155,10 @@ fn mva_lvv(mv: Move, board: &ChessBoard, options: &EngineOptions) -> f64 {
         return 0.0;
     }
 
+    if board.phase() <= 8 {
+        return 0.0;
+    }
+
     let piece_values = [
         options.sac_pawn_value(), 
         options.sac_knight_value(),


### PR DESCRIPTION
Elo   | 17.84 +- 9.02 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 3568 W: 1596 L: 1413 D: 559
Penta | [183, 217, 877, 248, 259]
https://jackalbench.pythonanywhere.com/test/264/