### PR TITLE
Widening

### DIFF
--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -45,11 +45,11 @@ create_options! {
             exploration_tau:       f64  =>  0.51,  0.0,  1.0,  0.055,  0.002;
 
             //Progressive widening
-            policy_percentage:       f64  =>  0.7,  0.1,  1.0,    0.05,  0.002;
-            min_policy_actions:      i64  =>  6,    1,    32,     1,     0.002;
-            initial_visit_threshold: i64  =>  8,    0,    1024,   1,     0.002;
-            visit_increase_multi:    f64  =>  2.0,  1.0,  10.0,   0.1,   0.002;
-            visit_increase_offset:   f64  =>  4.0,  1.0,  10.0,   0.1,   0.002;
+            policy_percentage:       f64  =>  0.6407,  0.1,  1.0,    0.05,  0.002;
+            min_policy_actions:      i64  =>  3,       1,    32,     1,     0.002;
+            initial_visit_threshold: i64  =>  9,       0,    1024,   1,     0.002;
+            visit_increase_multi:    f64  =>  2.2623,  1.0,  10.0,   0.1,   0.002;
+            visit_increase_offset:   f64  =>  4.1092,  1.0,  10.0,   0.1,   0.002;
 
             //Draw Scaling
             draw_scaling_power: f64  =>  3.0,     1.0,  10.0,  0.3,     0.002;

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -28,15 +28,28 @@ create_options! {
             winning_pst_threshold: f64  =>  0.6,   0.01,  1.0,   0.06,   0.002;
             winning_pst_max:       f64  =>  1.6,   0.01,  10.0,  0.016,  0.002;
 
-            //Node Selection
-            start_cpuct:           f64  =>  1.2813,    0.1,    5.0,      0.128,    0.002;
-            end_cpuct:             f64  =>  0.3265,    0.0,    1.0,      0.032,    0.002;
-            cpuct_depth_decay:     f64  =>  0.264101,  0.0,    5.0,      0.02641,  0.002;
-            cpuct_visit_scale:     f64  =>  8000.00,   128.0,  65536.0,  800.0,    0.002;
-            cpuct_variance_scale:  f64  =>  0.2,       0.1,    50.0,     0.02,     0.002;
-            cpuct_variance_weight: f64  =>  0.85,      0.0,    2.0,      0.085,    0.002;
-            cpuct_var_warmup:      f64  =>  0.5,       0.0,    1.0,      0.05,     0.002;
-            exploration_tau:       f64  =>  0.51,      0.0,    1.0,      0.055,    0.002;
+            //CPUCT
+            start_cpuct:           f64  =>  1.2813,    0.1,  5.0,  0.05,     0.002;
+            end_cpuct:             f64  =>  0.3265,    0.1,  1.0,  0.015,    0.002;
+            cpuct_depth_decay:     f64  =>  0.264101,  0.1,  5.0,  0.02641,  0.002;
+
+            //Visit scaling
+            cpuct_visit_scale:     f64  =>  8000.00,  4096.0,  65536.0,  250.0,  0.002;
+
+            //Variance scaling
+            cpuct_variance_scale:  f64  =>  0.2,   0.1,  50.0,  0.02,   0.002;
+            cpuct_variance_weight: f64  =>  0.85,  0.0,  2.0,   0.085,  0.002;
+            cpuct_var_warmup:      f64  =>  0.5,   0.0,  1.0,   0.05,   0.002;
+
+            //Exploration scale
+            exploration_tau:       f64  =>  0.51,  0.0,  1.0,  0.055,  0.002;
+
+            //Progressive widening
+            policy_percentage:       f64  =>  0.7,  0.1,  1.0,    0.05,  0.002;
+            min_policy_actions:      i64  =>  6,    1,    32,     1,     0.002;
+            initial_visit_threshold: i64  =>  8,    0,    1024,   1,     0.002;
+            visit_increase_multi:    f64  =>  2.0,  1.0,  10.0,   0.1,   0.002;
+            visit_increase_offset:   f64  =>  4.0,  1.0,  10.0,   0.1,   0.002;
 
             //Draw Scaling
             draw_scaling_power: f64  =>  3.0,     1.0,  10.0,  0.3,     0.002;
@@ -104,11 +117,11 @@ create_options! {
             hash_size: f64  =>  0.04,  0.01,  0.5,  0.004,  0.002;
 
             //Contempt
-            max_reasonable_s: f64  =>  2.0,     0.0,    100.0,    0.2,    0.002;
-            book_exit_bias:   f64  =>  0.65,    0.0,    1.0,      0.065,  0.002;
-            draw_rate_target: f64  =>  0.0,     0.0,    1.0,      0.01,   0.002;
-            draw_rate_ref:    f64  =>  0.65,    0.0,    1.0,      0.065,  0.002;
-            contempt_att:     f64  =>  1.0,     -10.0,  10.0,     0.1,    0.002;
+            max_reasonable_s: f64  =>  2.0,   0.0,    100.0,  0.2,    0.002;
+            book_exit_bias:   f64  =>  0.65,  0.0,    1.0,    0.065,  0.002;
+            draw_rate_target: f64  =>  0.0,   0.0,    1.0,    0.01,   0.002;
+            draw_rate_ref:    f64  =>  0.65,  0.0,    1.0,    0.065,  0.002;
+            contempt_att:     f64  =>  1.0,   -10.0,  10.0,   0.1,    0.002;
         }
     }
 }

--- a/engine/src/search_engine/tree/node.rs
+++ b/engine/src/search_engine/tree/node.rs
@@ -189,10 +189,14 @@ impl Node {
         self.children_count.store(chilren_count as u8, Ordering::Relaxed);
     }
 
-    pub fn map_children<F: FnMut(NodeIndex)>(&self, mut func: F) {
+    pub fn map_children<F: FnMut(NodeIndex)>(&self, func: F) {
+        self.map_children_with_limit(usize::MAX, func);
+    }
+
+    pub fn map_children_with_limit<F: FnMut(NodeIndex)>(&self, limit: usize, mut func: F) {
         let children_idx = self.children_index();
 
-        for child_idx in 0..self.children_count() {
+        for child_idx in 0..limit.min(self.children_count()) {
             func(children_idx + child_idx)
         }
     }

--- a/engine/src/search_engine/tree/tree_utils.rs
+++ b/engine/src/search_engine/tree/tree_utils.rs
@@ -12,12 +12,21 @@ impl Tree {
     pub fn select_child_by_key<F: FnMut(&Node) -> f64>(
         &self,
         parent_idx: NodeIndex,
+        key: F,
+    ) -> Option<NodeIndex> {
+        self.select_child_by_key_with_limit(parent_idx, self[parent_idx].children_count(), key)
+    }
+
+    pub fn select_child_by_key_with_limit<F: FnMut(&Node) -> f64>(
+        &self,
+        parent_idx: NodeIndex,
+        limit: usize,
         mut key: F,
     ) -> Option<NodeIndex> {
         let mut best_idx = None;
         let mut best_score = f64::NEG_INFINITY;
 
-        self[parent_idx].map_children(|child_idx| {
+        self[parent_idx].map_children_with_limit(limit, |child_idx| {
             let new_score = key(&self[child_idx]);
             if new_score > best_score {
                 best_idx = Some(child_idx);


### PR DESCRIPTION
Elo   | 8.84 +- 5.71 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.16 (-2.94, 2.94) [0.00, 5.00]
Games | N: 8572 W: 3600 L: 3382 D: 1590
Penta | [446, 608, 2037, 672, 523]
https://jackalbench.pythonanywhere.com/test/267/

Elo   | 6.89 +- 4.93 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.98 (-2.94, 2.94) [0.00, 5.00]
Games | N: 10796 W: 4313 L: 4099 D: 2384
Penta | [507, 853, 2524, 947, 567]
https://jackalbench.pythonanywhere.com/test/268/