### PR TITLE
Butterfly history

### DIFF
--- a/engine/src/search_engine.rs
+++ b/engine/src/search_engine.rs
@@ -12,6 +12,7 @@ mod tree;
 mod engine_options;
 mod hash_table;
 mod contempt;
+mod butterfly_history;
 
 pub use search_limits::SearchLimits;
 pub use search_stats::SearchStats;

--- a/engine/src/search_engine/butterfly_history.rs
+++ b/engine/src/search_engine/butterfly_history.rs
@@ -1,0 +1,59 @@
+use std::sync::atomic::{AtomicI16, Ordering};
+
+use chess::{Move, Side, Square};
+
+use crate::{search_engine::engine_options::EngineOptions, WDLScore};
+
+#[derive(Debug)]
+pub struct ButterflyHistory(Vec<AtomicI16>);
+
+impl Clone for ButterflyHistory {
+    fn clone(&self) -> Self {
+        Self(self.0.iter().map(|x| AtomicI16::new(x.load(Ordering::Relaxed))).collect())
+    }
+}
+
+impl ButterflyHistory {
+    pub fn new() -> Self {
+        Self((0..8192).map(|_| AtomicI16::new(0)).collect())
+    }
+
+    pub fn clear(&self) {
+        for entry in &self.0 {
+            entry.store(0, Ordering::Relaxed);
+        }
+    }
+
+    pub fn get_bonus(&self, side: Side, mv: Move, options: &EngineOptions) -> f64 {
+        f64::from(self.entry(side, mv).load(Ordering::Relaxed)) / (options.butterfly_bonus_scale() as f64)
+    }
+
+    pub fn update_entry(&self, side: Side, mv: Move, score: WDLScore, options: &EngineOptions) {
+        let entry = self.entry(side, mv);
+
+        let mut current_entry = entry.load(Ordering::Relaxed);
+        loop {
+            let delta = scale_bonus(current_entry, score.cp(), options.butterfly_reduction_factor() as i32);
+            let new = current_entry.saturating_add(delta);
+            match entry.compare_exchange(current_entry, new, Ordering::Relaxed, Ordering::Relaxed) {
+                Ok(_) => break,
+                Err(actual) => current_entry = actual,
+            }
+        }
+    }
+
+    fn index(side: Side, from: Square, to: Square) -> usize {
+        usize::from(side) * 4096 + usize::from(from) * 64 + usize::from(to)
+    }
+
+    fn entry(&self, side: Side, mv: Move) -> &AtomicI16 {
+        &self.0[Self::index(side, mv.get_from_square(), mv.get_to_square())]
+    }
+}
+
+fn scale_bonus(score: i16, bonus: i32, reduction_factor: i32) -> i16 {
+    let bonus = bonus.clamp(i16::MIN as i32, i16::MAX as i32);
+    let reduction = i32::from(score) * bonus.abs() / reduction_factor;
+    let adjusted = bonus - reduction;
+    adjusted.clamp(i16::MIN as i32, i16::MAX as i32) as i16
+}

--- a/engine/src/search_engine/engine_options.rs
+++ b/engine/src/search_engine/engine_options.rs
@@ -6,19 +6,21 @@ create_options! {
     EngineOptions {
         Options {
             //====== General ======
-            ["Hash"]         hash:           i64   =>  32,  1,  524288;
-            ["Threads"]      threads:        i64   =>  1,   1,  1024;
-            ["MoveOverhead"] move_overhead:  i64   =>  25,  0,  2000;
-            ["MultiPV"]      multi_pv:       i64   =>  1,   1,  218;
-            ["UCI_Chess960"] chess960:       bool  =>  false;
-            ["UCI_ShowWDL"]  show_wdl:       bool  =>  false;
-            ["MinimalPrint"] minimal_print:  bool  =>  false;
-            ["ItersAsNodes"] iters_as_nodes: bool  =>  false;
+            ["Hash"]         hash:          i64   =>  32,  1,  524288;
+            ["Threads"]      threads:       i64   =>  1,   1,  1024;
+            ["MoveOverhead"] move_overhead: i64   =>  25,  0,  2000;
+            ["MultiPV"]      multi_pv:      i64   =>  1,   1,  218;
+            ["UCI_Chess960"] chess960:      bool  =>  false;
+            ["UCI_ShowWDL"]  show_wdl:      bool  =>  false;
 
             //======== EAS ========
             ["Contempt"]  contempt:   i64  =>  1000,  -10000,  10000;
             ["DrawScore"] draw_score: i64  =>  30,    -100,    100;
             ["PolicySac"] policy_sac: i64  =>  10,    0,       100;
+
+            //======= Debug =======
+            ["MinimalPrint"] minimal_print:  bool  =>  false;
+            ["ItersAsNodes"] iters_as_nodes: bool  =>  false;
         }
         Tunables {
             //PST
@@ -50,6 +52,10 @@ create_options! {
             initial_visit_threshold: i64  =>  9,       0,    1024,   1,     0.002;
             visit_increase_multi:    f64  =>  2.2623,  1.0,  10.0,   0.1,   0.002;
             visit_increase_offset:   f64  =>  4.1092,  1.0,  10.0,   0.1,   0.002;
+
+            //Butterfly history
+            butterfly_reduction_factor: i64 => 8192,   1,  65536,   819,   0.002;
+            butterfly_bonus_scale:      i64 => 16384,  1,  131072,  1638,  0.002;
 
             //Draw Scaling
             draw_scaling_power: f64  =>  3.0,     1.0,  10.0,  0.3,     0.002;

--- a/engine/src/search_engine/tree/tree_expand.rs
+++ b/engine/src/search_engine/tree/tree_expand.rs
@@ -31,7 +31,8 @@ impl Tree {
 
         board.map_legal_moves(|mv| {
             let see = board.see(mv, -108);
-            let p = PolicyNetwork.forward(board, &policy_inputs, mv, &mut policy_cache, see) as f64 + usize::from(!see) as f64 * mva_lvv(mv, board, engine_options);
+            let mut p = PolicyNetwork.forward(board, &policy_inputs, mv, &mut policy_cache, see) as f64 + usize::from(!see) as f64 * mva_lvv(mv, board, engine_options);
+            p += self.butterfly_history().get_bonus(board.side(), mv, engine_options);
             policy.push((mv, p));
             max = max.max(p);
         });
@@ -112,7 +113,8 @@ impl Tree {
         self[node_idx].map_children(|child_idx| {
             let mv = self[child_idx].mv();
             let see = board.see(mv, -108);
-            let p = PolicyNetwork.forward(board, &policy_inputs, mv, &mut policy_cache, see) as f64 + usize::from(!see) as f64 * mva_lvv(mv, board, engine_options);
+            let mut p = PolicyNetwork.forward(board, &policy_inputs, mv, &mut policy_cache, see) as f64 + usize::from(!see) as f64 * mva_lvv(mv, board, engine_options);
+            p += self.butterfly_history().get_bonus(board.side(), mv, engine_options);
             policy.push(p);
             max = max.max(p);
         });


### PR DESCRIPTION
Elo   | 27.57 +- 11.47 (95%)
SPRT  | 10.0+0.10s Threads=1 Hash=32MB
LLR   | 3.03 (-2.94, 2.94) [0.00, 5.00]
Games | N: 2336 W: 1047 L: 862 D: 427
Penta | [115, 151, 521, 196, 185]
https://jackalbench.pythonanywhere.com/test/269/

Elo   | 34.06 +- 12.38 (95%)
SPRT  | 40.0+0.40s Threads=1 Hash=64MB
LLR   | 2.96 (-2.94, 2.94) [0.00, 5.00]
Games | N: 1658 W: 717 L: 555 D: 386
Penta | [54, 111, 386, 175, 103]
https://jackalbench.pythonanywhere.com/test/270/